### PR TITLE
feat: create detecated folders for easier UX when importing

### DIFF
--- a/public/localPrograms/Readme.md
+++ b/public/localPrograms/Readme.md
@@ -1,0 +1,1 @@
+## you put all your localy saved json files that you want to use, inside this folder.

--- a/public/localPrograms/demo program 0-1677200216139.json
+++ b/public/localPrograms/demo program 0-1677200216139.json
@@ -1,0 +1,75 @@
+{
+  "id": 1677200216139,
+  "title": "demo program 0",
+  "amountOfScreens": 2,
+  "segments": [
+    {
+      "id": 87897156,
+      "title": "Intro",
+      "description": "In the example, we use the useState hook to create a state variable",
+      "isIntro": true,
+      "screens": [
+        {
+          "id": 1677413125403,
+          "title": "intro screeen",
+          "mediaSrc": "/programMedia/60fps_Tester.mp4"
+        }
+      ],
+      "nextSegmentIds": [
+        65465465,
+        65465465465,
+        654654
+      ]
+    },
+    {
+      "id": 65465465,
+      "title": "#1 sequence",
+      "description": "custom description",
+      "screens": [
+        {
+          "id": 1677413150482,
+          "title": "sequ 1 screen ",
+          "mediaSrc": "/programMedia/Audio Video Sync Test 60 FPS.mp4"
+        }
+      ]
+    },
+    {
+      "id": 65465465465,
+      "title": "#2 sequence",
+      "description": "custom description",
+      "screens": [
+        {
+          "id": 6586,
+          "title": "screen2",
+          "mediaSrc": "/programMedia/Audio Video Sync Test 60 FPS.mp4"
+        },
+        {
+          "id": 65542,
+          "title": "screen1",
+          "mediaSrc": "/programMedia/60fps_Tester.mp4"
+        }
+      ]
+    },
+    {
+      "id": 654654,
+      "title": "doubled",
+      "description": "custom description",
+      "screens": [
+        {
+          "id": 653464,
+          "title": "screen1",
+          "mediaSrc": "/programMedia/60fps_Tester.mp4"
+        },
+        {
+          "id": 43523521,
+          "title": "screen2",
+          "mediaSrc": "/programMedia/Audio Video Sync Test 60 FPS.mp4"
+        }
+      ],
+      "nextSegmentIds": [
+        65465465,
+        65465465465
+      ]
+    }
+  ]
+}

--- a/public/programMedia/Readme.md
+++ b/public/programMedia/Readme.md
@@ -1,0 +1,1 @@
+## you put all your mp4 media files that you want to use, inside this folder.

--- a/src/components/LoadLocalProgramButton/LoadLocalProgramButton.tsx
+++ b/src/components/LoadLocalProgramButton/LoadLocalProgramButton.tsx
@@ -10,7 +10,7 @@ export const LoadLocalProgramButtonRaw = () => {
 
   const handleImportJsonProgram = useCallback(
     (e: any) => {
-      loadJsonProgram('/' + e.target.files[0].name)
+      loadJsonProgram('/localPrograms/' + e.target.files[0].name)
     },
     [loadJsonProgram]
   )

--- a/src/components/ScreenFormPopup/ScreenFormPopup.tsx
+++ b/src/components/ScreenFormPopup/ScreenFormPopup.tsx
@@ -29,7 +29,7 @@ export const ScreenFormPopupRaw = ({
       const screen = {
         id: generateNewId(),
         title: titleRef.current?.value || 'screen title',
-        mediaSrc: `/${e.target.files[0].name}`,
+        mediaSrc: `/programMedia/${e.target.files[0].name}`,
       }
       addScreenToSegment(segmentId, screen)
       onClose()


### PR DESCRIPTION
This PR is a small patch that creates two folders: 
- localPrograms: user move or copy saved json files of pre-configured programs inside it and then import it.
- programMedia: user can move or copy mp4 media files that he wants to use as screen media in the program.
