### PR TITLE
feat: implement easy method to identify screens

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -121,4 +121,11 @@ io.on('connection', (socket) => {
     // eslint-disable-next-line no-console
     console.log(`👌 - `, args)
   })
+
+  socket.on('identify-screens', (args) => {
+    socket.broadcast.emit('identify-screens', args)
+    socket.emit('identify-screens', args)
+    // eslint-disable-next-line no-console
+    console.log(`⁉️ - `, args)
+  })
 })

--- a/src/Pages/AdminPage/AdminPage.tsx
+++ b/src/Pages/AdminPage/AdminPage.tsx
@@ -7,6 +7,7 @@ import {
   PlayArrowOutlined,
   ReplayOutlined,
   SettingsOutlined,
+  Fingerprint,
 } from '@mui/icons-material'
 
 import {
@@ -28,7 +29,7 @@ const StyledActionsContainer = styled.div`
   gap: 15px;
   margin-bottom: 20px;
 
-  > :last-child {
+  > :nth-last-child(2) {
     margin-left: auto;
   }
 `
@@ -102,6 +103,15 @@ export const AdminPageRaw = () => {
                 startIcon={<ReplayOutlined />}
               >
                 Reset
+              </MainButton>
+
+              <MainButton
+                variant={MainButtonVariants.PRIMARY}
+                width={'fit-content'}
+                onClick={socketService.emmitIdentifyScreens}
+                startIcon={<Fingerprint />}
+              >
+                Identify Screens
               </MainButton>
 
               <MainButton

--- a/src/components/Screen/Screen.tsx
+++ b/src/components/Screen/Screen.tsx
@@ -22,6 +22,18 @@ const StyledScreenPlayerContainer = styled.div`
   }
 `
 
+const StyledIdentityWrapper = styled.div`
+  position: absolute;
+  z-index: 100;
+  bottom: 25px;
+  left: 25px;
+  span {
+    color: white;
+    font-size: 2rem;
+    font-weight: bold;
+  }
+`
+
 export type ScreenProps = {
   screenId: number
   screenService: ScreenService
@@ -43,6 +55,7 @@ export const ScreenRaw = ({
 }: ScreenProps) => {
   const programStarted = useScreenStore((s) => s.programStarted)
   const program = useScreenStore((s) => s.program)
+  const showIdentification = useScreenStore((s) => s.showIdentification)
   const playerContainerRef = useRef<any>()
   const videoRef1 = useRef<any>()
   const videoRef2 = useRef<any>()
@@ -63,6 +76,8 @@ export const ScreenRaw = ({
 
   useDoubleKeyPress('f', () => requestFullScreen())
   useDoubleKeyPress('c', () => requestShowControls())
+
+  // useEffect that
 
   const onRecivedScreenReady = useCallback(
     (recivedScreenId: number) => {
@@ -116,6 +131,15 @@ export const ScreenRaw = ({
         <VideoPlayer reference={videoRef1} muted={muted} />
         <VideoPlayer reference={videoRef2} muted={muted} />
       </>
+      {showIdentification && (
+        <StyledIdentityWrapper>
+          <span>
+            {program
+              ? `${screenId}: ${program.screensInfo[screenId].title}`
+              : `Screen id: ${screenId}`}
+          </span>
+        </StyledIdentityWrapper>
+      )}
     </StyledScreenPlayerContainer>
   )
 }

--- a/src/components/Screen/Screen.tsx
+++ b/src/components/Screen/Screen.tsx
@@ -77,8 +77,6 @@ export const ScreenRaw = ({
   useDoubleKeyPress('f', () => requestFullScreen())
   useDoubleKeyPress('c', () => requestShowControls())
 
-  // useEffect that
-
   const onRecivedScreenReady = useCallback(
     (recivedScreenId: number) => {
       if (recivedScreenId === screenId) setShowOverlay(false)

--- a/src/services/ScreenService/useScreenService.ts
+++ b/src/services/ScreenService/useScreenService.ts
@@ -10,6 +10,7 @@ export function useScreenService(
 ) {
   const setProgram = useScreenStore((s) => s.setProgram)
   const setProgramStarted = useScreenStore((s) => s.setProgramStarted)
+  const setShowIdentification = useScreenStore((s) => s.setShowIdentification)
   const addLogToLogsArray = useAdminStore((s) => s.addLogToLogsArray)
 
   const playPauseScreen = useCallback(() => {
@@ -82,6 +83,14 @@ export function useScreenService(
     [screenPlayerService]
   )
 
+  const showIdentificationTemporarly = useCallback(() => {
+    setShowIdentification(true)
+    const timeout = setTimeout(() => {
+      setShowIdentification(false)
+    }, 5000)
+    return () => clearTimeout(timeout)
+  }, [setShowIdentification])
+
   const setScreenListeners = useCallback(() => {
     if (!socketService) return
     socketService.onSetProgram(setScreenProgram)
@@ -91,6 +100,7 @@ export function useScreenService(
     socketService.onToggleShowControls(toggleShowingControls)
     socketService.onUserSelectedNextSegment(setSelectedNextSegment)
     socketService.onAnything(addLogToLogsArray)
+    socketService.onIdentifyScreens(showIdentificationTemporarly)
   }, [
     addLogToLogsArray,
     pauseProgram,
@@ -100,6 +110,7 @@ export function useScreenService(
     socketService,
     startProgram,
     toggleShowingControls,
+    showIdentificationTemporarly,
   ])
 
   const destroySocket = useCallback(() => {

--- a/src/services/SocketService/socketService.service.ts
+++ b/src/services/SocketService/socketService.service.ts
@@ -60,6 +60,10 @@ export class SocketService {
     this.emmit(EventNames.USER_SELECTED_SEGMENT, index)
   }
 
+  public emmitIdentifyScreens = () => {
+    this.emmit(EventNames.IDENTIFY_SCREENS, 'admin identifing screens')
+  }
+
   public onAnything = (exicute: (log: EventLog) => void) => {
     this._socket.onAny((eventName: string, args) => {
       exicute({ event: eventName, timestamp: Date.now() })
@@ -120,5 +124,9 @@ export class SocketService {
 
   public onToggleShowControls = (exicute: () => void) => {
     this.onLisiten(EventNames.TOGGLE_SHOW_CONTROLS, exicute)
+  }
+
+  public onIdentifyScreens = (exicute: () => void) => {
+    this.onLisiten(EventNames.IDENTIFY_SCREENS, exicute, true)
   }
 }

--- a/src/stores/screen/store.ts
+++ b/src/stores/screen/store.ts
@@ -11,15 +11,23 @@ export type ScreenState = {
 
   showControls: boolean
   setShowControls: (showControls: boolean) => void
+
+  showIdentification: boolean
+  setShowIdentification: (showIdentification: boolean) => void
 }
 
 export const useScreenStore = create<ScreenState>((set) => ({
   program: undefined,
   setProgram: (program: ProgramType | undefined) => set(() => ({ program })),
+
   programStarted: false,
   setProgramStarted: (programStarted: boolean) =>
     set(() => ({ programStarted })),
 
   showControls: false,
   setShowControls: (showControls: boolean) => set(() => ({ showControls })),
+
+  showIdentification: false,
+  setShowIdentification: (showIdentification: boolean) =>
+    set(() => ({ showIdentification })),
 }))

--- a/src/types/eventNames.ts
+++ b/src/types/eventNames.ts
@@ -12,6 +12,7 @@ export enum EventNames {
   REQUEST_FULLSCREEN = 'request-fullscreen',
   USER_SELECTED_SEGMENT = 'user-selected-segment',
   SCREEN_IS_READY = 'screen-is-ready',
+  IDENTIFY_SCREENS = 'identify-screens',
 }
 
 export type EventLog = {


### PR DESCRIPTION
This PR addes a small feature that allowes the admin to identify what screen is ment to be which screen.
With a click of a button : 
![image](https://user-images.githubusercontent.com/19777742/233860992-643cdff1-78a4-4e60-bc72-0cb5dfa473f7.png)

A text is showed indicating the screen id and the title of it when the program is set:
![image](https://user-images.githubusercontent.com/19777742/233861045-54794bcd-25a8-4ffa-8327-4d1070a5804a.png)

The identiy text will be shown for 5 seconds after the click and will disappear after that.